### PR TITLE
perf: use HttpCompletionOption.ResponseHeadersRead to avoid buffering response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 ### Changed
+- Use HttpCompletionOption.ResponseHeadersRead in ExecuteWithClientAsync to avoid buffering the full response body when only the status code is needed
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/HealthCheckClientTests.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/HealthCheckClientTests.cs
@@ -185,6 +185,24 @@ public sealed class HealthCheckClientTests : TestBase
         );
     }
 
+    [Fact]
+    public async ValueTask ExecuteAsync_WithSuccessResponseAndLargeBody_ReturnsZero()
+    {
+        ILogger<HealthCheckClientTests> logger = this.GetTypedLogger<HealthCheckClientTests>();
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        using LargeBodyHandler handler = new();
+
+        int result = await HealthCheckClient.ExecuteAsync(
+            targetUrl: VALID_URL,
+            handler: handler,
+            logger: logger,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: 0, actual: result);
+    }
+
     private sealed class FixedResponseHandler(HttpStatusCode statusCode) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
@@ -204,6 +222,22 @@ public sealed class HealthCheckClientTests : TestBase
         )
         {
             throw new HttpRequestException("Simulated connection failure");
+        }
+    }
+
+    private sealed class LargeBodyHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            HttpResponseMessage response = new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(new string(c: 'x', count: 1_000_000)),
+            };
+
+            return Task.FromResult(response);
         }
     }
 }

--- a/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
@@ -75,7 +75,11 @@ public static class HealthCheckClient
         try
         {
             using (
-                HttpResponseMessage r = await httpClient.GetAsync(requestUri: uri, cancellationToken: cancellationToken)
+                HttpResponseMessage r = await httpClient.GetAsync(
+                    requestUri: uri,
+                    completionOption: HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken: cancellationToken
+                )
             )
             {
                 if (!r.IsSuccessStatusCode)


### PR DESCRIPTION
## Summary

- Pass `HttpCompletionOption.ResponseHeadersRead` to `httpClient.GetAsync` in `ExecuteWithClientAsync` so the call completes as soon as headers arrive, eliminating unnecessary memory usage, bandwidth consumption, and latency — the response body is never read.
- Add a test with a `LargeBodyHandler` (1 MB body) to confirm the method returns success (`0`) without errors when the body is not consumed.

## Test plan

- [ ] All existing 28 tests continue to pass unchanged.
- [ ] New test `ExecuteAsync_WithSuccessResponseAndLargeBody_ReturnsZero` passes on both net9.0 and net10.0 target frameworks.

Closes #57