### PR TITLE
perf: compute safeUri lazily only on health-check failure paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Fixed
 ### Changed
 - Use HttpCompletionOption.ResponseHeadersRead in ExecuteWithClientAsync to avoid buffering the full response body when only the status code is needed
+- Compute the sanitised health-check URI lazily, only when logging a failure, instead of unconditionally on every request
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
@@ -67,11 +67,6 @@ public static class HealthCheckClient
         CancellationToken cancellationToken
     )
     {
-        string safeUri = uri.GetComponents(
-            UriComponents.Scheme | UriComponents.Host | UriComponents.Port | UriComponents.Path,
-            UriFormat.UriEscaped
-        );
-
         try
         {
             using (
@@ -84,7 +79,7 @@ public static class HealthCheckClient
             {
                 if (!r.IsSuccessStatusCode)
                 {
-                    logger.HealthCheckUnhealthy(statusCode: r.StatusCode, uri: safeUri);
+                    logger.HealthCheckUnhealthy(statusCode: r.StatusCode, uri: SafeUri(uri));
 
                     return HEALTHCHECK_FAIL;
                 }
@@ -98,10 +93,18 @@ public static class HealthCheckClient
         }
         catch (Exception exception)
         {
-            logger.HealthCheckFailed(safeUri, exception);
+            logger.HealthCheckFailed(SafeUri(uri), exception);
 
             return HEALTHCHECK_FAIL;
         }
+    }
+
+    private static string SafeUri(Uri uri)
+    {
+        return uri.GetComponents(
+            UriComponents.Scheme | UriComponents.Host | UriComponents.Port | UriComponents.Path,
+            UriFormat.UriEscaped
+        );
     }
 
     private static HttpClient CreateHttpClient()


### PR DESCRIPTION
## Summary

`HealthCheckClient.ExecuteWithClientAsync` currently computes the sanitised `safeUri` string unconditionally before every request, even though it is only used in the two failure/log paths. On the happy path (a healthy endpoint — the common case) this allocation is wasted.

This PR will move the `safeUri` computation into a small helper invoked only from the failure branches, so the happy path avoids the allocation entirely.

Closes #59

## Test plan

- [ ] Extract `SafeUri(Uri uri)` helper and call it only in the unhealthy/failure branches
- [ ] `dotnet build` succeeds
- [ ] `dotnet test` passes with no behavioural change (existing `HealthCheckClientTests` cover healthy, unhealthy, and throwing paths)