### PR TITLE
fix: set explicit HttpClient timeout so a hung health-check endpoint fails fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
-- Placeholder: set an explicit HttpClient timeout so a hung health-check endpoint fails fast instead of stalling for up to 100s
+- HealthCheckClient now sets an explicit HttpClient timeout (default 10s, overridable via a new ExecuteAsync timeout parameter) so a hung health-check endpoint fails fast instead of stalling for up to 100s
 ### Changed
 - Use HttpCompletionOption.ResponseHeadersRead in ExecuteWithClientAsync to avoid buffering the full response body when only the status code is needed
 - Compute the sanitised health-check URI lazily, only when logging a failure, instead of unconditionally on every request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- Placeholder: set an explicit HttpClient timeout so a hung health-check endpoint fails fast instead of stalling for up to 100s
 ### Changed
 - Use HttpCompletionOption.ResponseHeadersRead in ExecuteWithClientAsync to avoid buffering the full response body when only the status code is needed
 - Compute the sanitised health-check URI lazily, only when logging a failure, instead of unconditionally on every request

--- a/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/HealthCheckClientTests.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/HealthCheckClientTests.cs
@@ -92,6 +92,39 @@ public sealed class HealthCheckClientTests : TestBase
     }
 
     [Fact]
+    public async ValueTask ExecuteAsync_WithoutTimeoutParameter_WithInvalidUrlFormat_ReturnsOne()
+    {
+        ILogger<HealthCheckClientTests> logger = this.GetTypedLogger<HealthCheckClientTests>();
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        int result = await HealthCheckClient.ExecuteAsync(
+            targetUrl: INVALID_URL,
+            logger: logger,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: 1, actual: result);
+    }
+
+    [Fact]
+    public async ValueTask ExecuteAsync_WithoutTimeoutParameterAndHandler_WithSuccessResponse_ReturnsZero()
+    {
+        ILogger<HealthCheckClientTests> logger = this.GetTypedLogger<HealthCheckClientTests>();
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        using FixedResponseHandler handler = new(HttpStatusCode.OK);
+
+        int result = await HealthCheckClient.ExecuteAsync(
+            targetUrl: VALID_URL,
+            handler: handler,
+            logger: logger,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: 0, actual: result);
+    }
+
+    [Fact]
     public async ValueTask ExecuteAsync_WithSuccessResponse_ReturnsZero()
     {
         ILogger<HealthCheckClientTests> logger = this.GetTypedLogger<HealthCheckClientTests>();

--- a/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/HealthCheckClientTests.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/HealthCheckClientTests.cs
@@ -83,6 +83,7 @@ public sealed class HealthCheckClientTests : TestBase
 
         int result = await HealthCheckClient.ExecuteAsync(
             targetUrl: INVALID_URL,
+            timeout: null,
             logger: logger,
             cancellationToken: cancellationToken
         );
@@ -101,6 +102,7 @@ public sealed class HealthCheckClientTests : TestBase
         int result = await HealthCheckClient.ExecuteAsync(
             targetUrl: VALID_URL,
             handler: handler,
+            timeout: null,
             logger: logger,
             cancellationToken: cancellationToken
         );
@@ -123,6 +125,7 @@ public sealed class HealthCheckClientTests : TestBase
         int result = await HealthCheckClient.ExecuteAsync(
             targetUrl: VALID_URL,
             handler: handler,
+            timeout: null,
             logger: logger,
             cancellationToken: cancellationToken
         );
@@ -150,6 +153,7 @@ public sealed class HealthCheckClientTests : TestBase
         int result = await HealthCheckClient.ExecuteAsync(
             targetUrl: INVALID_URL,
             handler: handler,
+            timeout: null,
             logger: logger,
             cancellationToken: cancellationToken
         );
@@ -169,6 +173,7 @@ public sealed class HealthCheckClientTests : TestBase
         int result = await HealthCheckClient.ExecuteAsync(
             targetUrl: VALID_URL,
             handler: handler,
+            timeout: null,
             logger: logger,
             cancellationToken: cancellationToken
         );
@@ -196,11 +201,41 @@ public sealed class HealthCheckClientTests : TestBase
         int result = await HealthCheckClient.ExecuteAsync(
             targetUrl: VALID_URL,
             handler: handler,
+            timeout: null,
             logger: logger,
             cancellationToken: cancellationToken
         );
 
         Assert.Equal(expected: 0, actual: result);
+    }
+
+    [Fact]
+    public async ValueTask ExecuteAsync_WhenEndpointHangsBeyondTimeout_ReturnsOne()
+    {
+        ILogger<HealthCheckClientTests> logger = this.GetTypedLogger<HealthCheckClientTests>();
+        logger.IsEnabled(LogLevel.Error).Returns(true);
+        CancellationToken cancellationToken = this.CancellationToken();
+
+        using HangingHandler handler = new();
+
+        int result = await HealthCheckClient.ExecuteAsync(
+            targetUrl: VALID_URL,
+            handler: handler,
+            timeout: TimeSpan.FromMilliseconds(200),
+            logger: logger,
+            cancellationToken: cancellationToken
+        );
+
+        Assert.Equal(expected: 1, actual: result);
+        Assert.Contains(
+            logger.ReceivedCalls(),
+            call =>
+                StringComparer.Ordinal.Equals(call.GetMethodInfo().Name, "Log")
+                && call.GetArguments()[0] is LogLevel logLevel
+                && logLevel == LogLevel.Error
+                && call.GetArguments()[1] is EventId eventId
+                && eventId.Id == 0
+        );
     }
 
     private sealed class FixedResponseHandler(HttpStatusCode statusCode) : HttpMessageHandler
@@ -222,6 +257,19 @@ public sealed class HealthCheckClientTests : TestBase
         )
         {
             throw new HttpRequestException("Simulated connection failure");
+        }
+    }
+
+    private sealed class HangingHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
         }
     }
 

--- a/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
@@ -15,6 +15,11 @@ public static class HealthCheckClient
 
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
 
+    public static ValueTask<int> ExecuteAsync(string targetUrl, ILogger logger, in CancellationToken cancellationToken)
+    {
+        return ExecuteAsync(targetUrl: targetUrl, timeout: null, logger: logger, cancellationToken: cancellationToken);
+    }
+
     public static async ValueTask<int> ExecuteAsync(
         string targetUrl,
         TimeSpan? timeout,
@@ -36,6 +41,22 @@ public static class HealthCheckClient
                 cancellationToken: cancellationToken
             );
         }
+    }
+
+    public static ValueTask<int> ExecuteAsync(
+        string targetUrl,
+        HttpMessageHandler handler,
+        ILogger logger,
+        in CancellationToken cancellationToken
+    )
+    {
+        return ExecuteAsync(
+            targetUrl: targetUrl,
+            handler: handler,
+            timeout: null,
+            logger: logger,
+            cancellationToken: cancellationToken
+        );
     }
 
     public static async ValueTask<int> ExecuteAsync(

--- a/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
@@ -13,8 +13,11 @@ public static class HealthCheckClient
     private const int HEALTHCHECK_SUCCESS = 0;
     private const int HEALTHCHECK_FAIL = 1;
 
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
     public static async ValueTask<int> ExecuteAsync(
         string targetUrl,
+        TimeSpan? timeout,
         ILogger logger,
         CancellationToken cancellationToken
     )
@@ -24,7 +27,7 @@ public static class HealthCheckClient
             return HEALTHCHECK_FAIL;
         }
 
-        using (HttpClient httpClient = CreateHttpClient())
+        using (HttpClient httpClient = CreateHttpClient(timeout))
         {
             return await ExecuteWithClientAsync(
                 uri: uri,
@@ -38,6 +41,7 @@ public static class HealthCheckClient
     public static async ValueTask<int> ExecuteAsync(
         string targetUrl,
         HttpMessageHandler handler,
+        TimeSpan? timeout,
         ILogger logger,
         CancellationToken cancellationToken
     )
@@ -49,7 +53,7 @@ public static class HealthCheckClient
             return HEALTHCHECK_FAIL;
         }
 
-        using (HttpClient httpClient = CreateHttpClient(handler))
+        using (HttpClient httpClient = CreateHttpClient(handler: handler, timeout: timeout))
         {
             return await ExecuteWithClientAsync(
                 uri: uri,
@@ -107,19 +111,20 @@ public static class HealthCheckClient
         );
     }
 
-    private static HttpClient CreateHttpClient()
+    private static HttpClient CreateHttpClient(TimeSpan? timeout)
     {
-        return ConfigureHttpClient(new HttpClient());
+        return ConfigureHttpClient(httpClient: new HttpClient(), timeout: timeout);
     }
 
-    private static HttpClient CreateHttpClient(HttpMessageHandler handler)
+    private static HttpClient CreateHttpClient(HttpMessageHandler handler, TimeSpan? timeout)
     {
-        return ConfigureHttpClient(new HttpClient(handler, disposeHandler: false));
+        return ConfigureHttpClient(httpClient: new HttpClient(handler, disposeHandler: false), timeout: timeout);
     }
 
-    private static HttpClient ConfigureHttpClient(HttpClient httpClient)
+    private static HttpClient ConfigureHttpClient(HttpClient httpClient, TimeSpan? timeout)
     {
         httpClient.DefaultRequestHeaders.ConnectionClose = true;
+        httpClient.Timeout = timeout ?? DefaultTimeout;
 
         return httpClient;
     }

--- a/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client/HealthCheckClient.cs
@@ -15,9 +15,26 @@ public static class HealthCheckClient
 
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
 
-    public static ValueTask<int> ExecuteAsync(string targetUrl, ILogger logger, in CancellationToken cancellationToken)
+    public static async ValueTask<int> ExecuteAsync(
+        string targetUrl,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
     {
-        return ExecuteAsync(targetUrl: targetUrl, timeout: null, logger: logger, cancellationToken: cancellationToken);
+        if (!Uri.TryCreate(uriString: targetUrl, uriKind: UriKind.Absolute, out Uri? uri))
+        {
+            return HEALTHCHECK_FAIL;
+        }
+
+        using (HttpClient httpClient = CreateHttpClient(timeout: null))
+        {
+            return await ExecuteWithClientAsync(
+                uri: uri,
+                httpClient: httpClient,
+                logger: logger,
+                cancellationToken: cancellationToken
+            );
+        }
     }
 
     public static async ValueTask<int> ExecuteAsync(
@@ -43,20 +60,29 @@ public static class HealthCheckClient
         }
     }
 
-    public static ValueTask<int> ExecuteAsync(
+    public static async ValueTask<int> ExecuteAsync(
         string targetUrl,
         HttpMessageHandler handler,
         ILogger logger,
-        in CancellationToken cancellationToken
+        CancellationToken cancellationToken
     )
     {
-        return ExecuteAsync(
-            targetUrl: targetUrl,
-            handler: handler,
-            timeout: null,
-            logger: logger,
-            cancellationToken: cancellationToken
-        );
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (!Uri.TryCreate(uriString: targetUrl, uriKind: UriKind.Absolute, out Uri? uri))
+        {
+            return HEALTHCHECK_FAIL;
+        }
+
+        using (HttpClient httpClient = CreateHttpClient(handler: handler, timeout: null))
+        {
+            return await ExecuteWithClientAsync(
+                uri: uri,
+                httpClient: httpClient,
+                logger: logger,
+                cancellationToken: cancellationToken
+            );
+        }
     }
 
     public static async ValueTask<int> ExecuteAsync(


### PR DESCRIPTION
## Summary

Implements the approved plan from #58: the internally-created `HttpClient` in `HealthCheckClient` has no explicit `Timeout`, so a hung endpoint blocks up to `HttpClient`'s 100s default instead of failing within Docker's healthcheck window — see `## Implementation Plan` comment on the issue for the full approved plan.

This PR currently contains only the branch scaffold (placeholder CHANGELOG entry). Implementation follows in the next cycle.

## Design note for implementation (found while scaffolding — not yet resolved)

The approved plan has an internal contradiction that the implementer needs to resolve:

- **Approach** says: hardcode `httpClient.Timeout = TimeSpan.FromSeconds(10);` inside the existing private `ConfigureHttpClient`, with **no public API surface change**.
- **Test strategy** says: the test should set `HttpClient.Timeout` to a very short duration (e.g. 50ms) so the test stays fast.

These can't both hold: `ConfigureHttpClient` is private and hardcodes the timeout, so a test calling the public `ExecuteAsync(string, HttpMessageHandler, ILogger, CancellationToken)` overload has no seam to shorten it — the test would have to actually wait ~10s for a hung `DelayingHandler`, which is a poor unit test.

Also confirmed while reviewing the existing catch logic in `ExecuteWithClientAsync`: `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)` rethrows — so cancelling the *caller's* token surfaces as a thrown exception, not a logged `HEALTHCHECK_FAIL`. Only a genuine client-side timeout (caller token NOT cancelled) reaches the `HealthCheckFailed` (EventId 0) path the test is meant to assert. So a short-timeout test seam is genuinely required, not optional.

Two clean resolutions (either is defensible; picking (a) keeps the plan's "no public API change" assumption intact):

- **(a)** Add an internal overload of `ConfigureHttpClient`/`CreateHttpClient` that accepts a `TimeSpan`, with `[InternalsVisibleTo]` added for the test project; public methods keep calling it with a 10s default.
- **(b)** Expose the optional `TimeSpan` timeout parameter on `ExecuteAsync` that the original issue itself offered as an alternative.

Closes #58