### PR TITLE
chore: drop net9.0 target, support net10.0 only (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 ### Changed
-- Placeholder: drop net9.0 support so the client and its tests target net10.0 only
+- Drop net9.0 support: client and tests now target net10.0 only
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -10,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 ### Changed
+- Placeholder: drop net9.0 support so the client and its tests target net10.0 only
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/Credfeto.Docker.HealthCheck.Http.Client.Tests.csproj
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client.Tests/Credfeto.Docker.HealthCheck.Http.Client.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Docker.HealthCheck.Http.Client/Credfeto.Docker.HealthCheck.Http.Client.csproj
+++ b/src/Credfeto.Docker.HealthCheck.Http.Client/Credfeto.Docker.HealthCheck.Http.Client.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-docker-http-healthcheck-client</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary

Implements the approved plan from #67: drop `net9.0` from the repository's multi-targeted projects so both `Credfeto.Docker.HealthCheck.Http.Client` and its test project target `net10.0` only - see the `## Implementation Plan` comment on the issue for the full approved plan.

This PR currently contains only the branch scaffold (placeholder CHANGELOG entry). Implementation follows in the next cycle.

## Notes for implementation (found while scaffolding)

A repo-wide grep for `net9.0` confirms exactly two matches, both plain `<TargetFrameworks>net9.0;net10.0</TargetFrameworks>` elements with no attached `Condition`:

- `src/Credfeto.Docker.HealthCheck.Http.Client/Credfeto.Docker.HealthCheck.Http.Client.csproj`
- `src/Credfeto.Docker.HealthCheck.Http.Client.Tests/Credfeto.Docker.HealthCheck.Http.Client.Tests.csproj`

No `net9.0`-specific MSBuild `Condition`s, `#if NET9_0` (non-`_OR_GREATER`) guards, or `net9.0` references in `global.json`, `Directory.Build.props`, or any `.github/workflows/*.yml` file exist elsewhere in the repo, so the change is a straightforward two-line edit with nothing else to clean up.

Local verification of the change (not yet committed, reverted before scaffolding this PR):

- `dotnet buildcheck -Solution src/Credfeto.Docker.HealthCheck.Http.Client.slnx` - no errors
- `dotnet build -c Release` - succeeds, 0 warnings/errors
- `dotnet test -c Release` - 18/18 tests pass

Closes #67
